### PR TITLE
MV3 support for build-watch

### DIFF
--- a/generator/generate/editPackage.js
+++ b/generator/generate/editPackage.js
@@ -2,7 +2,7 @@
 module.exports = (api, isTypeScript) => {
   const extPkg = {
     scripts: {
-      'build-watch': 'vue-cli-service build-watch --mode development'
+      'build-watch': 'vue-cli-service  --env.NODE_ENV=development build-watch --mode development'
     },
     devDependencies: {
       'copy-webpack-plugin': '^4.6.0'

--- a/generator/template/vue.config.js
+++ b/generator/template/vue.config.js
@@ -25,6 +25,8 @@ chromeName.forEach((name) => {
   }
 })
 
+const isDevMode = process.env.NODE_ENV === 'development'
+
 module.exports = {
   pages,
   filenameHashing: false,
@@ -40,6 +42,7 @@ module.exports = {
     output: {
       filename: `js/[name].js`,
       chunkFilename: `[name].js`
-    }
+    },
+    devtool: isDevMode ? 'inline-source-map' : false,
   }
 }


### PR DESCRIPTION
### Re: #14 

Updated vue config and npm script to support manifest V3 for `build-watch`

Note: `NODE_ENV` is needed to be `development` when running `build-watch`